### PR TITLE
GH action - set CNAME for pages action

### DIFF
--- a/.github/actions/buildresources/action.yaml
+++ b/.github/actions/buildresources/action.yaml
@@ -48,6 +48,7 @@ runs:
         publish_dir: book/_build/html
         publish_branch: gh-pages
         enable_jekyll: false
+        cname: snowex.hackweek.io
 
     - name: Save Build
       if: ${{ always() && inputs.jb-save == 'true'}}


### PR DESCRIPTION
Testing the theory that the actions-gh-pages@v3 needs this set and overwrites settings under the UI tab.