### PR TITLE
Fix dates to actual planned week

### DIFF
--- a/cookiecutter.yaml
+++ b/cookiecutter.yaml
@@ -10,8 +10,8 @@ hackweek_mission: https://uwhackweek.github.io/hackweeks-as-a-service/mission.ht
 banner:
   title: SnowEx Hackweek
   description: An in person, collaborative learning event.
-  start_date: 11 July
-  end_date: 15 July
+  start_date: 10 July
+  end_date: 14 July
   year: 2023
   location: Seattle, WA
   links:


### PR DESCRIPTION
Noticed yesterday when advertising the event that the dates on the splash page are shifted by one day